### PR TITLE
fix: generate with `strict` mode

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -31,7 +31,7 @@ const http_raw = () => {
 
     yield seq(...repeat(6, seq(h16, ':')), ls32);
     yield seq('::', ...repeat(5, seq(h16, ':')), ls32);
-    for (i = 0; i < 5; i++) {
+    for (let i = 0; i < 5; i++) {
       yield seq(
         optional(seq(h16, ...repeat(i, optional(seq(':', h16))))),
         '::',


### PR DESCRIPTION
The grammar will fail to evaluate if JS is run in 'strict mode', since the variable assignment in the loop is assigned as a global, which is disallowed in strict mode.